### PR TITLE
Remove npm from the test toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,17 @@ DOCKER_JOB := $(DOCKER) run --rm -it
 default: build
 
 build:
-	$(DOCKER) build -t $(image_name) .
+	@$(DOCKER) build -t $(image_name) .
 .PHONY: build
 
+TEST_FILES ?= $(wildcard tests/*_test.js)
+TEST_CMD ?= mocha --compilers js:babel-register $(TEST_FILES)
 test:
-	$(call job, npm run test)
+	@$(call job, $(TEST_CMD))
 .PHONY: test
 
-
 shell:
-	$(call job, bash)
+	@$(call job, bash)
 .PHONY: shell
 
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "gulp build && node app.js",
-    "test": "mocha --compilers js:babel-register $(find tests -name '*_test.js')"
+    "start": "gulp build && node app.js"
   },
   "devDependencies": {
     "babel": "6.3.13",


### PR DESCRIPTION
@phil-linnell now `make test` does not use npm so on failure it does not show any annoying backtrace.